### PR TITLE
fix failing tests

### DIFF
--- a/tests/unit/example.spec.js
+++ b/tests/unit/example.spec.js
@@ -9,7 +9,8 @@ localVue.use(VeeValidate, { inject: false });
 describe('App', () => {
   const wrapper = mount(App, {
     sync: false,
-    localVue
+    localVue,
+    attachToDocument: true
   });
 
   it('first_name requires a value', async () => {
@@ -29,10 +30,11 @@ describe('App', () => {
     expect(wrapper.vm.errors.has('framework')).toBe(true);
 
     const radio = wrapper.find('#vue');
-    radio.setChecked(true);
+    radio.element.checked = true;
+    radio.trigger('change');
     await flushPromises();
 
-    await wrapper.vm.$validator.validate('framework')
+    await wrapper.vm.$validator.validate('framework');
     expect(wrapper.vm.errors.has('framework')).toBe(false);
   });
 });


### PR DESCRIPTION
This PR fixes the radio test by:

- I have replaced the `setChecked` call with the documented equivalent.
- set the `attachToDocument` option to `true` on the mounting options.

The first one is probably an issue with the async rendering and vue-test-utils itself, while `attachToDocument` fixes the issue because vee-validate uses `document.querySelector` to find the radio "siblings" to validate them as well.
